### PR TITLE
Disable GPU sandbox for WSL2 compatibility

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,9 @@ function checkTokens() {
   }
 }
 
+// Disable GPU sandbox for WSL2/wslg compatibility
+app.commandLine.appendSwitch('disable-gpu-sandbox');
+
 app.whenReady().then(() => {
   // Check process arguments
   const p = new Promise<void>((resolve, _) => {


### PR DESCRIPTION
Hi, running your app in WSL2 (using wslg) I consistently run into the following error:

```shell
libva error: vaGetDriverNames() failed with unknown libva error
[15374:1222/112716.407635:FATAL:gpu_data_manager_impl_private.cc(415)] GPU process isn't usable. Goodbye.
/home/lars/temp/teams-token/node_modules/electron/dist/electron exited with signal SIGTRAP
```

Because electron doesn't support hardware acceleration in WSL, it requires configuring the following setting:
```ts
app.commandLine.appendSwitch('disable-gpu-sandbox');
```